### PR TITLE
fix: Update GitHub Actions workflow to use correct mise-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,13 @@ jobs:
 
       # Setup Mise (or directly Rustup) for toolchain management
       - name: Setup Mise
-        uses: jdxcode/mise@v1
+        uses: jdx/mise-action@v2
         with:
-          version: 'latest'
+          version: latest
+          install: true
 
       - name: Use project-defined tools with Mise
-        run: mise use --install
+        run: mise install
 
       - name: Check formatting
         run: make fmt
@@ -42,6 +43,9 @@ jobs:
         run: make release
 
       # Optional: Run security audit
+      - name: Install cargo-audit
+        run: cargo install cargo-audit
+        
       - name: Run cargo audit
-        run: mise run -- cargo audit --deny warnings || true
+        run: cargo audit --deny warnings || true
         continue-on-error: true


### PR DESCRIPTION
## Summary
- Fix GitHub Actions workflow failure by using the correct mise-action
- Update mise commands to match current mise CLI
- Add cargo-audit installation step

## Changes
- Change from non-existent `jdxcode/mise@v1` to `jdx/mise-action@v2`
- Update mise command from `mise use --install` to `mise install`
- Add cargo-audit installation step before running audit
- Remove unnecessary `mise run --` prefix from cargo audit command

## Test Plan
This PR will test the workflow changes when the CI runs.

🤖 Generated with [Claude Code](https://claude.ai/code)