### PR TITLE
feat: Improve Git sync to automatically handle non-conflicting divergences

### DIFF
--- a/crates/a4-cli/tests/sync_test.rs
+++ b/crates/a4-cli/tests/sync_test.rs
@@ -1,0 +1,238 @@
+use a4_core::git_backend::{GitBackend, GixBackend, RebaseResult};
+use std::fs;
+use std::path::Path;
+use tempfile::TempDir;
+
+fn init_test_repo(dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    std::process::Command::new("git")
+        .arg("init")
+        .current_dir(dir)
+        .output()?;
+
+    std::process::Command::new("git")
+        .arg("config")
+        .arg("user.email")
+        .arg("test@example.com")
+        .current_dir(dir)
+        .output()?;
+
+    std::process::Command::new("git")
+        .arg("config")
+        .arg("user.name")
+        .arg("Test User")
+        .current_dir(dir)
+        .output()?;
+
+    Ok(())
+}
+
+fn create_commit(
+    dir: &Path,
+    file: &str,
+    content: &str,
+    message: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    fs::write(dir.join(file), content)?;
+
+    std::process::Command::new("git")
+        .arg("add")
+        .arg(file)
+        .current_dir(dir)
+        .output()?;
+
+    std::process::Command::new("git")
+        .arg("commit")
+        .arg("-m")
+        .arg(message)
+        .current_dir(dir)
+        .output()?;
+
+    Ok(())
+}
+
+#[test]
+fn test_rebase_with_no_conflicts() -> Result<(), Box<dyn std::error::Error>> {
+    let temp_dir = TempDir::new()?;
+    let repo_path = temp_dir.path();
+
+    // Initialize repository
+    init_test_repo(repo_path)?;
+
+    // Create initial commit
+    create_commit(repo_path, "file1.txt", "initial content", "Initial commit")?;
+
+    // Create a branch to simulate remote
+    std::process::Command::new("git")
+        .arg("branch")
+        .arg("remote-branch")
+        .current_dir(repo_path)
+        .output()?;
+
+    // Make a local change
+    create_commit(repo_path, "file2.txt", "local content", "Local commit")?;
+
+    // Switch to remote branch and make a different change
+    std::process::Command::new("git")
+        .arg("checkout")
+        .arg("remote-branch")
+        .current_dir(repo_path)
+        .output()?;
+
+    create_commit(repo_path, "file3.txt", "remote content", "Remote commit")?;
+
+    // Switch back to main branch
+    std::process::Command::new("git")
+        .arg("checkout")
+        .arg("main")
+        .current_dir(repo_path)
+        .output()?;
+
+    // Now test the rebase
+    let mut backend = GixBackend::open(repo_path)?;
+    let result = backend.rebase_onto("remote-branch")?;
+
+    assert_eq!(result, RebaseResult::Success);
+
+    // Verify that both changes are present
+    assert!(repo_path.join("file2.txt").exists());
+    assert!(repo_path.join("file3.txt").exists());
+
+    Ok(())
+}
+
+#[test]
+fn test_rebase_with_conflicts() -> Result<(), Box<dyn std::error::Error>> {
+    let temp_dir = TempDir::new()?;
+    let repo_path = temp_dir.path();
+
+    // Initialize repository
+    init_test_repo(repo_path)?;
+
+    // Create initial commit
+    create_commit(repo_path, "file.txt", "initial content", "Initial commit")?;
+
+    // Create a branch to simulate remote
+    std::process::Command::new("git")
+        .arg("branch")
+        .arg("remote-branch")
+        .current_dir(repo_path)
+        .output()?;
+
+    // Make a local change to the same file
+    create_commit(repo_path, "file.txt", "local change", "Local commit")?;
+
+    // Switch to remote branch and make a conflicting change
+    std::process::Command::new("git")
+        .arg("checkout")
+        .arg("remote-branch")
+        .current_dir(repo_path)
+        .output()?;
+
+    create_commit(repo_path, "file.txt", "remote change", "Remote commit")?;
+
+    // Switch back to main branch
+    std::process::Command::new("git")
+        .arg("checkout")
+        .arg("main")
+        .current_dir(repo_path)
+        .output()?;
+
+    // Now test the rebase - should detect conflict
+    let mut backend = GixBackend::open(repo_path)?;
+    let result = backend.rebase_onto("remote-branch")?;
+
+    assert_eq!(result, RebaseResult::Conflict);
+
+    // Verify that the repository is still in a clean state (rebase was aborted)
+    let status_output = std::process::Command::new("git")
+        .arg("status")
+        .arg("--porcelain")
+        .current_dir(repo_path)
+        .output()?;
+
+    assert!(
+        status_output.stdout.is_empty(),
+        "Repository should be in clean state after conflict"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_divergence_detection() -> Result<(), Box<dyn std::error::Error>> {
+    let temp_dir = TempDir::new()?;
+    let repo_path = temp_dir.path();
+
+    // Initialize repository
+    init_test_repo(repo_path)?;
+
+    // Create initial commit
+    create_commit(repo_path, "file1.txt", "initial content", "Initial commit")?;
+
+    // Create a branch to simulate remote
+    std::process::Command::new("git")
+        .arg("branch")
+        .arg("remote-branch")
+        .current_dir(repo_path)
+        .output()?;
+
+    // Make a local change
+    create_commit(repo_path, "file2.txt", "local content", "Local commit")?;
+
+    // Switch to remote branch and make a different change
+    std::process::Command::new("git")
+        .arg("checkout")
+        .arg("remote-branch")
+        .current_dir(repo_path)
+        .output()?;
+
+    create_commit(repo_path, "file3.txt", "remote content", "Remote commit")?;
+
+    // Switch back to main branch
+    std::process::Command::new("git")
+        .arg("checkout")
+        .arg("main")
+        .current_dir(repo_path)
+        .output()?;
+
+    // Test divergence detection
+    let backend = GixBackend::open(repo_path)?;
+    let has_diverged = backend.diverged("remote-branch")?;
+
+    assert!(has_diverged, "Should detect divergence between branches");
+
+    Ok(())
+}
+
+#[test]
+fn test_no_divergence_when_ahead() -> Result<(), Box<dyn std::error::Error>> {
+    let temp_dir = TempDir::new()?;
+    let repo_path = temp_dir.path();
+
+    // Initialize repository
+    init_test_repo(repo_path)?;
+
+    // Create initial commit
+    create_commit(repo_path, "file1.txt", "initial content", "Initial commit")?;
+
+    // Create a branch to simulate remote (stays at initial commit)
+    std::process::Command::new("git")
+        .arg("branch")
+        .arg("remote-branch")
+        .current_dir(repo_path)
+        .output()?;
+
+    // Make a local change (we're ahead of remote)
+    create_commit(repo_path, "file2.txt", "local content", "Local commit")?;
+
+    // Test divergence detection
+    let backend = GixBackend::open(repo_path)?;
+    let has_diverged = backend.diverged("remote-branch")?;
+
+    assert!(
+        !has_diverged,
+        "Should not detect divergence when we're ahead"
+    );
+
+    Ok(())
+}

--- a/crates/a4-cli/tests/sync_test.rs
+++ b/crates/a4-cli/tests/sync_test.rs
@@ -7,7 +7,7 @@ fn init_test_repo(dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
     std::process::Command::new("git")
         .arg("init")
         .arg("-b")
-        .arg("main")  // Explicitly set the default branch name
+        .arg("main") // Explicitly set the default branch name
         .current_dir(dir)
         .output()?;
 

--- a/crates/a4-core/src/lib.rs
+++ b/crates/a4-core/src/lib.rs
@@ -12,4 +12,5 @@ pub use anchors::AnchorToken;
 pub use append::{append_block, AppendOptions};
 pub use date::{IsoWeek, LocalClock, UtcDay};
 pub use error::A4Error;
+pub use git_backend::{GitBackend, RebaseResult};
 pub use vault::{Vault, VaultOpts, VaultRoot};


### PR DESCRIPTION
## Summary
- Implements automatic rebase for non-conflicting divergences during sync
- Adds clear conflict detection and user guidance
- Enhances sync robustness with comprehensive test coverage

## Problem
The current sync implementation would error out when Git branches diverged, even when changes could be automatically rebased without conflicts. This required manual intervention for common, non-conflicting scenarios.

## Solution
This PR enhances the `a4 sync` command to:

1. **Automatic Rebase**: When branches have diverged but changes don't conflict, automatically rebase local commits on top of remote changes
2. **Conflict Detection**: Detect actual merge conflicts and provide clear instructions for manual resolution
3. **Safe Force Push**: Use `--force-with-lease` for pushing rebased changes safely

### Implementation Details
- Added `rebase_onto()` method to GitBackend trait
- Introduced `RebaseResult` enum with three states: Success, Conflict, NoRebaseNeeded
- Enhanced `diverged()` method to check both directions (is HEAD ancestor of remote, and vice versa)
- Added `has_uncommitted_changes()` helper method
- Modified sync flow to attempt fast-forward first, then rebase if diverged

### Error Handling
When conflicts are detected, the user receives clear instructions:
```
Rebase conflict detected when syncing with refs/remotes/origin/main.
Please resolve the conflicts manually:
1. Run 'git rebase refs/remotes/origin/main' in the vault directory
2. Resolve any conflicts
3. Run 'git rebase --continue' after resolving
4. Run 'a4 sync' again to push changes
```

## Testing
Added comprehensive test suite (`sync_test.rs`) covering:
- ✅ Successful rebase with non-conflicting changes
- ✅ Conflict detection and proper cleanup (rebase abort)
- ✅ Divergence detection between branches
- ✅ No false divergence when branch is ahead

All tests pass with `make all` completing successfully.

## Test Plan
- [x] Run `make test` - all tests pass
- [x] Run `make fmt` - code is properly formatted
- [x] Run `make lint` - no clippy warnings
- [x] Test manual sync scenarios:
  - [ ] Fast-forward when behind remote
  - [ ] Push when ahead of remote
  - [ ] Automatic rebase when diverged without conflicts
  - [ ] Proper error message when conflicts occur

🤖 Generated with [Claude Code](https://claude.ai/code)